### PR TITLE
Bugfix in get_cruise_variables

### DIFF
--- a/cmap4r/R/cruise_info.R
+++ b/cmap4r/R/cruise_info.R
@@ -36,7 +36,7 @@ get_cruises <- function(){
 #' #
 #' }
 get_cruise_variables <- function(cruiseName){
-  df = cruise_by_name(cruiseName)
+  df = get_cruise_by_name(cruiseName)
   exequery <- sprintf('SELECT * FROM dbo.udfCruiseVariables(%d) ',
                       df$ID[1])
   apiKey = get_api_key()


### PR DESCRIPTION
Hi all, I stumbled across a bug while trying to use cmap4r's `get_cruise_variables` function. Currently, the function throws an error:

```
> get_cruise_variables("MESO_SCOPE")
Error in cruise_by_name(cruiseName) : 
  could not find function "cruise_by_name"
```

because it looks like at some point the `cruise_by_name` function became `get_cruise_by_name` and wasn't propagated all the way through the package. Using a quick `trace` with `edit=TRUE` to change the original code from

```
df = cruise_by_name(cruiseName)
```

to 

```
df = get_cruise_by_name(cruiseName)
```
returns the expected result:

```
> get_cruise_variables("MESO_SCOPE")
 0s 0s 0s# A tibble: 128 x 34                                                                         
   Variable Table_Name Long_Name Unit  Make  Sensor Process_Level Study_Domain Temporal_Resolu~
    0s<chr>    <chr>      <chr>     <chr> <chr> <chr>  <chr>         <chr>        <chr>           
 1 sample_~ tblKM1709~ Sample N~ NA    Obse~ In-Si~ Reprocessed   Uncategoriz~ Irregular 
...
```

This PR implements this change in the master branch. I wasn't able to do unit testing but the package does compile and behave as expected when reconstructed using `devtools`.